### PR TITLE
コメント欄の要素のDOM指定方法変更

### DIFF
--- a/src/js/CommentMutationObserver.js
+++ b/src/js/CommentMutationObserver.js
@@ -108,12 +108,12 @@ export default function CommentMutationObserver(props) {
 
         /*****  コメント欄observe *****/ 
         // コメント欄はiframe
-        const iframeContents = commentElement.getElementsByTagName('iframe')[0].contentWindow.document.getElementById('item-offset').children[0]; 
+        const iframeContents = commentElement.getElementsByTagName('iframe')[0].contentWindow.document.querySelector('#item-offset #items'); 
         // コメント欄監視
         commentObserver = new MutationObserver((mutations) => {
             mutations.forEach((mutation) => {
                 mutation.addedNodes.forEach((contents) => {
-                    const message = contents.innerText.split('\n')[1];
+                    const message = contents.querySelector('#message').innerText;
 
                     // 特殊文字削除
                     let targetMessage = '';

--- a/src/js/Questionnaire.js
+++ b/src/js/Questionnaire.js
@@ -67,7 +67,8 @@ export default function Questionnaire() {
         }
         return true;
     }
-    domready(() => {
+
+    window.addEventListener('load', () => {
         const initObserve = setInterval(() => {
             if (document.getElementsByTagName('ytd-video-owner-renderer')[0]) {
                 


### PR DESCRIPTION
https://github.com/HigasaMimizuku1217/questionnaire-youtube/commit/9ac4267172ea7837462ecff85a0c3907bfe66f91

の修正内容ですありがとうございます。
コメントを取得する部分の方法の変更。

- [x] アンケートが開始できる
- [x] 得票が正しく計算される
- [x] アンケートが終了できる
- [x] アンケートが作り直せる
- [x] スパチャ、メンバーシップなどでエラーにならない